### PR TITLE
Support for finding eigen in conda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,11 +42,12 @@ class get_pybind_include(object):
         self.user = user
 
     def __str__(self):
+        if "PYBIND11_INCLUDE" in os.environ:
+            return os.environ["PYBIND11_INCLUDE"]
         if pybind11_path is not None:
             return os.path.join(os.environ["PYBIND11_DIR"], "include")
         else:
             import pybind11
-
             return pybind11.get_include(self.user)
 
 
@@ -61,11 +62,12 @@ class get_eigen_include(object):
         self.user = user
 
     def __str__(self):
+        if "EIGEN_INCLUDE" in os.environ:
+            return os.environ["EIGEN_INCLUDE"]
         if eigen_path is not None:
             return os.path.join(os.environ["EIGEN_DIR"], "include")
         else:
             import peigen
-
             return peigen.header_path
 
 

--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -3,6 +3,17 @@
 # This works around DM-5409, wherein mpi4py was attempting to use an OS X 10.5
 # SDK, based on querying Anaconda, and failing; and DM-6133, wherein distutils
 # refuses to let us target an earlier SDK than Python was compiled with.
+
+# Support for CONDA_PREFIX (conda-forge compilers)
+if [[ -n "$CONDA_PREFIX" ]]; then
+    export EIGEN_INCLUDE=$CONDA_PREFIX/include/eigen3
+fi
+
+# Inside conda-build (stackvana)
+if [[ "$CONDA_BUILD" == "1" ]]; then
+    export EIGEN_INCLUDE=$PREFIX/include/eigen3
+fi
+
 if [ -z "$MACOSX_DEPLOYMENT_TARGET" ]; then
     MIN_DEPLOYMENT_TARGET=9
     CFG_DEPLOYMENT_TARGET=$(python -c "import sysconfig; print((sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET') or '10.$MIN_DEPLOYMENT_TARGET').split('.')[1])")


### PR DESCRIPTION
This obviates the use of peigen when building in an activated conda environment (conda-forge).

We can't override EUPS_DIR in eupspkg.cfg.sh because the headers are namespaced (under eigen3), although an EIGEN_INCLUDE env var could be used instead - we've done that with eupspkg.cfg.sh